### PR TITLE
lessons: Check for ps aux header instead of systemd in ps aux test

### DIFF
--- a/data/lessons.json.unvalidated.in
+++ b/data/lessons.json.unvalidated.in
@@ -878,7 +878,7 @@
                 "input": "console",
                 "mapper": ["shell", "wrapped_output", {
                     "type": "regex",
-                    "value": "^.*1.*systemd"
+                    "value": "USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND"
                 }],
                 "example": {
                     "success": "ps aux",


### PR DESCRIPTION
What ps aux actually lists depends on the context in which it is
run. If it is started by d-bus activation it will be able to see
far more processes, including systemd.

https://phabricator.endlessm.com/T14436