### PR TITLE
bin: Set HOME explicitly

### DIFF
--- a/bin/showmehow-service.js.in
+++ b/bin/showmehow-service.js.in
@@ -32,9 +32,7 @@ const Service = imports.lib.service;
 // HOME might not be set if we're running through D-Bus activation, so
 // set the environment variable to the value of GLib.get_home_dir which will
 // fall back to passwd
-if (!GLib.getenv('HOME')) {
-    GLib.setenv('HOME', GLib.get_home_dir());
-}
+GLib.setenv('HOME', GLib.get_home_dir(), false);
 
 const ShowmehowServiceApplication = new Lang.Class({
     Name: 'ShowmehowServiceApplication',

--- a/bin/showmehow-service.js.in
+++ b/bin/showmehow-service.js.in
@@ -29,6 +29,12 @@ const Controller = imports.lib.controller;
 const Descriptors = imports.lib.descriptors;
 const Service = imports.lib.service;
 
+// HOME might not be set if we're running through D-Bus activation, so
+// set the environment variable to the value of GLib.get_home_dir which will
+// fall back to passwd
+if (!GLib.getenv('HOME')) {
+    GLib.setenv('HOME', GLib.get_home_dir());
+}
 
 const ShowmehowServiceApplication = new Lang.Class({
     Name: 'ShowmehowServiceApplication',


### PR DESCRIPTION
In the case that we were run through D-Bus activation, we won't
be run through a shell, in which case this won't be set for us.
Certain lessons rely on this to be set, so we can just use
GLib.get_home_dir() to find out its value. That function will
read /etc/passwd if HOME isn't set.

https://phabricator.endlessm.com/T14922