### PR TITLE
Adapt to gsetting lesson using now another schema

### DIFF
--- a/data/lessons.json.unvalidated.in
+++ b/data/lessons.json.unvalidated.in
@@ -264,10 +264,10 @@
                 "input": "console",
                 "mapper": ["shell", "raw_output", {
                     "type": "regex",
-                    "value": "^always-show-log-out$"
+                    "value": "^can-change-accels$"
                 }],
                 "example": {
-                    "success": "gsettings list-keys org.gnome.shell",
+                    "success": "gsettings list-keys org.gnome.desktop.interface",
                     "failure": "gsettings"
                 }
             },


### PR DESCRIPTION
Since we changed in modifying the clock-format
(which is part of org.gnome.desktop.interface) have to
change the verification of the entered command as well.