### PR TITLE
flatpak: Disable tests on arm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,8 +101,7 @@ install-data-local:
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	for i in $(lesson_directories); do \
 		mkdir -p $(DESTDIR)$(pkgdatadir)/$$i && \
-		cp -r $(srcdir)/$$i $$(dirname $(DESTDIR)$(pkgdatadir)/$$i/..) && \
-		chmod -R +w $(DESTDIR)$(pkgdatadir)/$$i; \
+		cp -r $(srcdir)/$$i $$(dirname $(DESTDIR)$(pkgdatadir)/$$i/..); \
 	done
 
 uninstall-local:

--- a/Makefile.am
+++ b/Makefile.am
@@ -101,7 +101,7 @@ install-data-local:
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	for i in $(lesson_directories); do \
 		mkdir -p $(DESTDIR)$(pkgdatadir)/$$i && \
-		cp -r $(srcdir)/$$i $(DESTDIR)$(pkgdatadir)/$$i/.. && \
+		cp -r $(srcdir)/$$i $$(dirname $(DESTDIR)$(pkgdatadir)/$$i/..) && \
 		chmod -R +w $(DESTDIR)$(pkgdatadir)/$$i; \
 	done
 

--- a/com.endlessm.ShowmehowService.json.in
+++ b/com.endlessm.ShowmehowService.json.in
@@ -216,8 +216,26 @@
             ]
         },
         {
-            "name": "showmehow-service",
+            "name": "showmehow-service-arm",
+            "run-tests": false,
+            "only-arches": ["arm"],
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "*.a"
+            ],
+            "sources": [
+                {
+                    "branch": "@GIT_CLONE_BRANCH@",
+                    "path": ".",
+                    "type": "git"
+                }
+            ]
+        },
+        {
+            "name": "showmehow-service-tests",
             "run-tests": "@RUN_TESTS@",
+            "skip-arches": ["arm"],
             "cleanup": [
                 "/include",
                 "/lib/pkgconfig",


### PR DESCRIPTION
Running these tests on Jenkins on the arm builder is a total
pain, since that builder is actually running them through
QEMU on an overloaded build worker. Since the tests are timing
dependent, they often fail because things are just too slow.

https://phabricator.endlessm.com/T23090