### PR TITLE
tests: Make sure to finish the async test on failure

### DIFF
--- a/tests/testShowmehowServiceContent.js
+++ b/tests/testShowmehowServiceContent.js
@@ -181,7 +181,9 @@ describe('Showmehow Service Lesson', function () {
                         let input = task.example[result];
                         it('returns ' + result + ' when called with ' + input, function(done) {
                             let errorHandler = function(domain, code, message) {
-                                throw new Error('Error ' + domain + ':' + code + ' "' + message + '" occurred');
+                                // Need to upgrade jasmine API to use fail()
+                                expect(`Error ${domain}: ${code} "${message}" occurred`).toEqual('');
+                                done();
                             };
 
                             let successHandler = function(response) {


### PR DESCRIPTION
We may be causing a timeout problem by not calling done() when the async
operation fails.

https://phabricator.endlessm.com/T23389